### PR TITLE
Add readByte() & readBytes(int) to BitReader.

### DIFF
--- a/src/main/java/com/tomgibara/bits/BitReader.java
+++ b/src/main/java/com/tomgibara/bits/BitReader.java
@@ -116,6 +116,36 @@ public interface BitReader extends BitStream {
 	}
 
 	/**
+	 * Reads eight bits from a stream of bits and returns them as a byte.
+	 *
+	 * @return the read bits as a byte
+	 * @throws BitStreamException
+	 *                        if an exception occurs when reading the stream
+	 */
+
+	default byte readByte() {
+		BitStore bits = Bits.store(8);
+		bits.readFrom(this);
+		return bits.toByteArray()[0];
+	}
+
+	/**
+	 * Reads the necessary bits from a stream of bits and returns them as a byte array.
+	 *
+	 * @param numberOfBytes
+	 *             the number of bytes to read
+	 * @return the read bits as a byte[]
+	 * @throws BitStreamException
+	 *                        if an exception occurs when reading the stream
+	 */
+
+	default byte[] readBytes(int numberOfBytes) {
+		BitStore bits = Bits.store(numberOfBytes * Byte.SIZE);
+		bits.readFrom(this);
+		return bits.toByteArray();
+	}
+
+	/**
 	 * Reads as many consecutive bits as possible together with a single
 	 * terminating bit of the opposite value and returns the number of
 	 * consecutive bits read.

--- a/src/main/java/com/tomgibara/bits/ByteArrayBitReader.java
+++ b/src/main/java/com/tomgibara/bits/ByteArrayBitReader.java
@@ -33,12 +33,12 @@ class ByteArrayBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected int readByte() throws BitStreamException {
+	protected int readSourceByte() throws BitStreamException {
 		return index == bytes.length ? -1 : bytes[index++] & 0xff;
 	}
 
 	@Override
-	protected long skipBytes(long count) throws BitStreamException {
+	protected long skipSourceBytes(long count) throws BitStreamException {
 		long limit = bytes.length - index;
 		if (count >= limit) {
 			index = bytes.length;
@@ -49,7 +49,7 @@ class ByteArrayBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long seekByte(long index) throws BitStreamException {
+	protected long seekSourceByte(long index) throws BitStreamException {
 		if (index >= bytes.length) {
 			this.index = bytes.length;
 			return bytes.length;

--- a/src/main/java/com/tomgibara/bits/ByteBasedBitReader.java
+++ b/src/main/java/com/tomgibara/bits/ByteBasedBitReader.java
@@ -67,7 +67,7 @@ abstract class ByteBasedBitReader implements BitReader {
 	// methods for overriding
 
 	/**
-	 * The next byte in the stream.
+	 * The next byte in the source stream.
 	 *
 	 * @return the next byte in the stream, or -1 if the end of the byte stream
 	 *         has been reached
@@ -76,10 +76,10 @@ abstract class ByteBasedBitReader implements BitReader {
 	 *             if an exception occurs when reading
 	 */
 
-	protected abstract int readByte() throws BitStreamException;
+	protected abstract int readSourceByte() throws BitStreamException;
 
 	/**
-	 * Instructs the byte stream to skip a specified number of bytes.
+	 * Instructs the source byte stream to skip a specified number of bytes.
 	 * Implementations are permitted to skip fewer, and possibly zero, bytes.
 	 * Any attempt to skip past the end of the stream should curtail the number
 	 * of bytes skipped and not necessarily raise a {@link BitStreamException}.
@@ -94,10 +94,10 @@ abstract class ByteBasedBitReader implements BitReader {
 	 *             if an exception occurs when skipping
 	 */
 
-	protected abstract long skipBytes(long count) throws BitStreamException;
+	protected abstract long skipSourceBytes(long count) throws BitStreamException;
 
 	/**
-	 * Instructs the byte stream to reposition itself so that the next read will
+	 * Instructs the source byte stream to reposition itself so that the next read will
 	 * return the byte at the specified index. Attempting to seek beyond the
 	 * length of the stream is not an error, in this case, implementations that
 	 * support seeking SHOULD return the first index after that of the last
@@ -107,14 +107,14 @@ abstract class ByteBasedBitReader implements BitReader {
 	 * consistently return -1L.
 	 *
 	 * @param index
-	 *            the next byte to be read via {@link #readByte()}
+	 *            the next byte to be read via {@link #readSourceByte()}
 	 * @return the index of the next byte that will be returned from
-	 *         {@link #readByte()}
+	 *         {@link #readSourceByte()}
 	 * @throws BitStreamException
 	 *             if an exception occurs when seeking
 	 */
 
-	protected abstract long seekByte(long index) throws BitStreamException;
+	protected abstract long seekSourceByte(long index) throws BitStreamException;
 
 	// public methods
 
@@ -122,7 +122,7 @@ abstract class ByteBasedBitReader implements BitReader {
 		BitStreams.checkPosition(position);
 		if (position != this.position) {
 			// is this necessary? preferable? position = Math.min(position, size);
-			long index = seekByte(position >> 3);
+			long index = seekSourceByte(position >> 3);
 			if (index < 0L) { // seeking not supported - skip whole distance
 				long count = position - this.position;
 				if (count > 0L) skipBits(count);
@@ -141,7 +141,7 @@ abstract class ByteBasedBitReader implements BitReader {
 		if (position == size) throw new EndOfBitStreamException();
 		int count = (int) position & 7;
 		if (count == 0) { // need new bits
-			buffer = readByte();
+			buffer = readSourceByte();
 			if (buffer == -1) throw new EndOfBitStreamException();
 		}
 		position++;
@@ -175,7 +175,7 @@ abstract class ByteBasedBitReader implements BitReader {
 		}
 
 		while (true) {
-			buffer = readByte();
+			buffer = readSourceByte();
 			if (buffer == -1) throw new EndOfBitStreamException();
 			if (count >= 8) {
 				value = (value << 8) | buffer;
@@ -199,7 +199,7 @@ abstract class ByteBasedBitReader implements BitReader {
 		int count = (int) position & 7;
 		while (true) {
 			if (count == 0) { // need new bits
-				buffer = readByte();
+				buffer = readSourceByte();
 				if (buffer == -1) throw new EndOfBitStreamException();
 			}
 			int t = lookup[(buffer << 3) | count];
@@ -258,9 +258,9 @@ abstract class ByteBasedBitReader implements BitReader {
 	private long skipFully(long count) {
 		long total = 0L;
 		while (total < count) {
-			long skipped = skipBytes(count);
+			long skipped = skipSourceBytes(count);
 			if (skipped == 0L) {
-				if (readByte() < 0) {
+				if (readSourceByte() < 0) {
 					break;
 				} else {
 					skipped = 1L;

--- a/src/main/java/com/tomgibara/bits/FileChannelBitReader.java
+++ b/src/main/java/com/tomgibara/bits/FileChannelBitReader.java
@@ -36,7 +36,7 @@ class FileChannelBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected int readByte() throws BitStreamException {
+	protected int readSourceByte() throws BitStreamException {
 		if (buffer.hasRemaining()) return buffer.get() & 0xff;
 		buffer.limit(buffer.capacity()).position(0);
 		try {
@@ -50,7 +50,7 @@ class FileChannelBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long seekByte(long index) throws BitStreamException {
+	protected long seekSourceByte(long index) throws BitStreamException {
 		// first see if index is inside buffer
 		if (bufferPosition >= 0) {
 			long offset = index - bufferPosition;
@@ -63,7 +63,7 @@ class FileChannelBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long skipBytes(long count) throws BitStreamException {
+	protected long skipSourceBytes(long count) throws BitStreamException {
 		// optimized code path, where skip fits inside buffer
 		if (count <= buffer.remaining()) {
 			buffer.position(buffer.position() + (int) count);

--- a/src/main/java/com/tomgibara/bits/InputStreamBitReader.java
+++ b/src/main/java/com/tomgibara/bits/InputStreamBitReader.java
@@ -28,7 +28,7 @@ class InputStreamBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected int readByte() throws BitStreamException {
+	protected int readSourceByte() throws BitStreamException {
 		try {
 			return in.read();
 		} catch (IOException e) {
@@ -37,7 +37,7 @@ class InputStreamBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long skipBytes(long count) throws BitStreamException {
+	protected long skipSourceBytes(long count) throws BitStreamException {
 		try {
 			return in.skip(count);
 		} catch (IOException e) {
@@ -46,7 +46,7 @@ class InputStreamBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long seekByte(long index) throws BitStreamException {
+	protected long seekSourceByte(long index) throws BitStreamException {
 		return -1L;
 	}
 

--- a/src/main/java/com/tomgibara/bits/StreamBitReader.java
+++ b/src/main/java/com/tomgibara/bits/StreamBitReader.java
@@ -30,7 +30,7 @@ class StreamBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected int readByte() throws BitStreamException {
+	protected int readSourceByte() throws BitStreamException {
 		try {
 			return stream.readByte() & 0xff;
 		} catch (EndOfStreamException e) {
@@ -41,7 +41,7 @@ class StreamBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long skipBytes(long count) throws BitStreamException {
+	protected long skipSourceBytes(long count) throws BitStreamException {
 		long c = 0;
 		while (c < count) try {
 			stream.readByte();
@@ -55,7 +55,7 @@ class StreamBitReader extends ByteBasedBitReader {
 	}
 
 	@Override
-	protected long seekByte(long index) throws BitStreamException {
+	protected long seekSourceByte(long index) throws BitStreamException {
 		return -1L;
 	}
 

--- a/src/test/java/com/tomgibara/bits/BitReaderTest.java
+++ b/src/test/java/com/tomgibara/bits/BitReaderTest.java
@@ -1,0 +1,134 @@
+package com.tomgibara.bits;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import junit.framework.TestCase;
+
+
+public class BitReaderTest extends TestCase {
+
+  /*
+   * Tests for 'readByte()'.
+   */
+
+  public void testReadByteWithTwoBytes() {
+
+    byte byte1 = (byte) 0b00000000;
+    byte byte2 = (byte) 0b11111111;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1, byte2});
+
+    assertEquals(byte1, bitReader.readByte());
+    assertEquals(byte2, bitReader.readByte());
+
+  }
+
+  public void testReadByteWithIntermixedBitReads() {
+
+    byte byte1 = (byte) 0b00001111;
+    byte byte2 = (byte) 0b11110000;
+    byte byte3 = (byte) 0b00000011;
+    byte byte4 = (byte) 0b00000111;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1, byte2, byte3, byte4});
+
+    assertFalse(bitReader.readBoolean());
+    assertFalse(bitReader.readBoolean());
+    assertFalse(bitReader.readBoolean());
+    assertFalse(bitReader.readBoolean());
+
+    assertEquals((byte) 0b11111111, bitReader.readByte());
+    assertEquals((byte) 0b00000000, bitReader.readByte());
+
+    assertFalse(bitReader.readBoolean());
+    assertFalse(bitReader.readBoolean());
+    assertTrue(bitReader.readBoolean());
+    assertTrue(bitReader.readBoolean());
+
+    assertArrayEquals(new byte[]{byte4}, bitReader.readBytes(1));
+
+  }
+
+  public void testReadByteWithoutEnoughBitsRemaining(){
+
+    byte byte1 = (byte) 0b00000000;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1});
+
+    bitReader.readBit();
+
+    try{
+      bitReader.readByte();
+      fail();
+    } catch (EndOfBitStreamException e){
+      /* expected */
+    }
+
+  }
+
+
+  /*
+   * Tests for 'readBytes()'.
+   */
+
+  public void testReadBytes() {
+
+    byte byte1 = (byte) 0b00000000;
+    byte byte2 = (byte) 0b00000001;
+    byte byte3 = (byte) 0b00000011;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1, byte2, byte3});
+
+    assertArrayEquals(new byte[]{byte1, byte2, byte3}, bitReader.readBytes(3));
+
+  }
+
+  public void testReadByteAndReadyByte() {
+
+    byte byte1 = (byte) 0b00000000;
+    byte byte2 = (byte) 0b00000001;
+    byte byte3 = (byte) 0b00000011;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1, byte2, byte3});
+
+    assertArrayEquals(new byte[]{byte1, byte2}, bitReader.readBytes(2));
+    assertEquals(byte3, bitReader.readByte());
+
+  }
+
+  public void testReadBytesWithIntermixedBitReads() {
+
+    byte byte1 = (byte) 0b10000000;
+    byte byte2 = (byte) 0b00000001;
+    byte byte3 = (byte) 0b00000011;
+    byte byte4 = (byte) 0b00000111;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1, byte2, byte3, byte4});
+
+    assertTrue(bitReader.readBoolean());
+    assertFalse(bitReader.readBoolean());
+    bitReader.skipBits(6);
+    assertArrayEquals(new byte[]{byte2, byte3}, bitReader.readBytes(2));
+    assertEquals(byte4, bitReader.readByte());
+
+  }
+
+  public void testReadBytesWithoutEnoughBitsRemaining(){
+
+    byte byte1 = (byte) 0b00000000;
+    byte byte2 = (byte) 0b00000001;
+
+    BitReader bitReader = Bits.readerFrom(new byte[]{byte1, byte2});
+
+    bitReader.readBit();
+
+    try{
+      bitReader.readBytes(2);
+      fail();
+    } catch (EndOfBitStreamException e){
+      /* expected */
+    }
+
+  }
+
+}


### PR DESCRIPTION
I have a use case where I need to do both bit level and byte level reads from the same source, however `BitReader` lacks byte level read methods. This PR adds `readByte()` and `readBytes(int)` methods using the `BitStore` which is similar to other methods.

Note that the `ByteArrayBitReader` class already contained a `readByte()` method, however it's purpose is to read a _source_ byte from the underlying implementation, so to avoid this clash I renamed methods used for managing the source.